### PR TITLE
Bump storage-kv

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "form-data": "^2.5.0",
     "isomorphic-fetch": "^2.2.1",
     "path-to-regexp": "^3.0.0",
-    "storage-kv": "^0.0.7",
+    "storage-kv": "^0.0.8",
     "yargs": "^13.2.4"
   }
 }


### PR DESCRIPTION
This depends on https://github.com/nickbalestra/storage-kv/pull/12, which removes engines requirement.