### PR TITLE
Route params bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "form-data": "^2.5.0",
     "isomorphic-fetch": "^2.2.1",
     "path-to-regexp": "^3.0.0",
-    "storage-kv": "^0.0.7",
+    "storage-kv": "^0.0.8",
     "yargs": "^13.2.4"
   }
 }

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -198,12 +198,15 @@ export class Router<ContextData = any> {
 
         const params: { [key: string]: string } = {}
 
+        // Starting from 1 because 0 is the whole pathname
+        let patternResultIndex = 1
+
         for (let i = 0; i < routeTokens.length; i++) {
           if (typeof routeTokens[i] === 'string') {
             continue
           } else {
             const token: pathToRegExp.Key = routeTokens[i] as any
-            params[token.name] = patternResult[i]
+            params[token.name] = patternResult[patternResultIndex++]
           }
         }
 


### PR DESCRIPTION
Fixing multiple params parsing bug. Currently, if you have 2+ params, they are not set correctly (undefined or whatever is in patternResult)