### PR TITLE
Fix params parsing bug, added tests for multiple params

### DIFF
--- a/src/Router.ts
+++ b/src/Router.ts
@@ -198,12 +198,16 @@ export class Router<ContextData = any> {
 
         const params: { [key: string]: string } = {}
 
+        // Starting from 1 because 0 is the whole pathname
+        // Params start from index 1
+        let patternResultIndex = 1
+
         for (let i = 0; i < routeTokens.length; i++) {
           if (typeof routeTokens[i] === 'string') {
             continue
           } else {
             const token: pathToRegExp.Key = routeTokens[i] as any
-            params[token.name] = patternResult[i]
+            params[token.name] = patternResult[patternResultIndex++]
           }
         }
 

--- a/src/Router_test.ts
+++ b/src/Router_test.ts
@@ -251,3 +251,25 @@ test('response editing in middleware should work', async t => {
     t.fail('Response was undefined')
   }
 })
+
+test('multiple params specified should all be defined', async t => {
+  mockGlobal()
+
+  const r = new Router()
+
+  // [type, userId, bookId]
+  const result: [string, string, string][] = []
+
+  r.get`/users/${'userId'}/books/${'bookId'}`.use(async (ctx, next) => {
+    result.push(['middleware', ctx.params.userId, ctx.params.bookId])
+    await next()
+  })
+
+  r.get`/users/${'userId'}/books/${'bookId'}`.handle(async ctx => {
+    result.push(['handler', ctx.params.userId, ctx.params.bookId])
+  })
+
+  await r.getResponseForRequest({ url: '/users/123/books/456', method: 'GET' } as Request)
+
+  t.deepEqual(result, [['middleware', '123', '456'], ['handler', '123', '456']])
+})


### PR DESCRIPTION
If you have more than one params, their values are set to undefined (or any other value that is in patternResult). We need to pick values from patternResult array more carefully.