### PR TITLE
Expand KVStatic Middleware options

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,8 +239,10 @@ import { Router, kvStatic } from '8track'
 
 const router = new Router()
 
-router.all`(.*)`.use(kvStatic({ kv: myKvNamespaceVar, maxAge: 24 * 60 * 60 * 30 }))
+router.all`(.*)`.use(kvStatic(kv: myKvNamespaceVar, { cacheControl: {browserTTL: 720, edgeTTL: 60 * 60 * 30, bypassCache:false}}))
 ```
+
+Note `myKvNamespaceVar` is the name of the binding to your script
 
 ## Deploying your worker
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:shebang": "printf '%s\n%s\n' \"#!/usr/bin/env node\n\" \"$(cat dist/cli.js)\" > dist/cli.js",
     "build:executable": "chmod +x dist/cli.js",
     "typecheck": "tsc --noEmit",
-    "test": "ava dist/*_test.js",
+    "test": "ava dist/*_test.js --verbose",
     "test:watch": "yarn test -w"
   },
   "author": "John Fawcett",

--- a/src/middleware/kv-static.ts
+++ b/src/middleware/kv-static.ts
@@ -1,16 +1,34 @@
 import { Middleware } from '../Router'
 import { KVNamespace } from '@cloudflare/workers-types'
+const cache = { put: (path: string, num: number) => {} }
 
-interface KVStaticOptions {
-  kv: KVNamespace
-  maxAge?: number
+type CacheOptions = {
+  browserTTL: number
+  edgeTTL: number
+  bypassCache: boolean
 }
-
+type SiteInit = {
+  /* handle requests that don't exist on the bucket */
+  notFoundHandler: (req: Request) => Response | Promise<Response>
+  /* configure how the incoming request's path is found in the bucket */
+  pathToKeyModifier: (path: string) => string
+  /* control the cache for all the site's content or on per request bias */
+  cacheControl: CacheOptions | ((req: Request) => CacheOptions)
+}
+const defaultSiteInit: SiteInit = {
+  notFoundHandler: () => new Response('Not Found', { status: 404 }),
+  pathToKeyModifier: (path: string) => path,
+  cacheControl: {
+    browserTTL: 720,
+    edgeTTL: 720,
+    bypassCache: false,
+  },
+}
 /**
  * Streams files out of KV if it exists
- * @param options
+ * TODO KVNamespace should come from the wrangler config .. ?
  */
-export function kvStatic(options: KVStaticOptions): Middleware {
+export function kvStatic(kv: KVNamespace, mOptions: Partial<SiteInit>): Middleware {
   return async (ctx, next) => {
     // TODO: Store mime types in KV as well
     const contentTypes = {
@@ -30,18 +48,39 @@ export function kvStatic(options: KVStaticOptions): Middleware {
     if (!supportedExtensions.some(ext => ctx.request.url.endsWith('.' + ext))) {
       return next()
     }
+    // set up options from mOptions passed in and the default options
+    const options = Object.assign({}, defaultSiteInit, mOptions)
+    // set cache options by either evaluating the handler passed in
+    // or whatever settings were passed in
+    let evalCacheOpts: CacheOptions = (function() {
+      switch (typeof mOptions.cacheControl) {
+        case 'function':
+          return mOptions.cacheControl(ctx.request)
+        case 'object':
+          return mOptions.cacheControl
+        case 'undefined': //just returns default cache settings, but type safe
+          return typeof defaultSiteInit.cacheControl === 'function'
+            ? defaultSiteInit.cacheControl(ctx.request)
+            : defaultSiteInit.cacheControl
+      }
+    })()
+    const cacheOpts: CacheOptions = Object.assign({}, defaultSiteInit.cacheControl, evalCacheOpts)
 
+    // TODO first try to match request will cache
+    // TODO eval path handler
     const filename = ctx.request.url.substring(ctx.request.url.lastIndexOf('/') + 1)
     const ext = filename.substring(filename.lastIndexOf('.') + 1)
     const contentType = contentTypes[ext as keyof typeof contentTypes] || 'text'
-    const body = await options.kv.get(filename, 'stream')
+    const body = await kv.get(filename, 'stream')
 
-    if (!body) return ctx.end('', { status: 404 })
+    if (cacheOpts.edgeTTL && !cacheOpts.bypassCache) cache.put(filename, cacheOpts.edgeTTL)
+
+    if (!body) return ctx.end(await options.notFoundHandler(ctx.request))
 
     return ctx.end(body, {
       headers: {
         'Content-Type': contentType,
-        'Cache-Control': options.maxAge ? `max-age=${options.maxAge}` : 'public',
+        'Cache-Control': `max-age=${cacheOpts.browserTTL}`,
       },
     })
   }

--- a/src/middleware/kv-static.ts
+++ b/src/middleware/kv-static.ts
@@ -7,33 +7,39 @@ type CacheOptions = {
   edgeTTL: number
   bypassCache: boolean
 }
-type SiteInit = {
+type KVSiteOptions = {
   /* handle requests that don't exist on the bucket */
   notFoundHandler: (req: Request) => Response | Promise<Response>
   /* configure how the incoming request's path is found in the bucket */
   keyModifier: (path: string) => string
   /* control the cache for all the site's content or on per request bias */
-  cacheControl: CacheOptions | ((req: Request) => CacheOptions)
+  cacheControl: Partial<CacheOptions> | ((req: Request) => Partial<CacheOptions>)
 }
-const defaultSiteInit: SiteInit = {
+type KVInit = {
+  /* Global KV namespace that is bound to the Worker script */
+  kv: Pick<KVNamespace, 'get'>
+  options: Partial<KVSiteOptions>
+}
+const defaultCacheControl: CacheOptions = {
+  browserTTL: 720,
+  edgeTTL: 720,
+  bypassCache: false,
+}
+const defaultKVSiteOptions: KVSiteOptions = {
   notFoundHandler: () => new Response('Not Found', { status: 404 }),
   keyModifier: (url: string) => {
     let parsedUrl = new URL(url)
     let path = parsedUrl.pathname
     return path.endsWith('/') ? path + 'index.html' : path
   },
-  cacheControl: {
-    browserTTL: 720,
-    edgeTTL: 720,
-    bypassCache: false,
-  },
+  cacheControl: defaultCacheControl,
 }
 /**
  * Streams files out of KV if it exists
- * TODO KVNamespace should come from the wrangler config .. ?
  */
-export function kvStatic(kv: any, mOptions: Partial<SiteInit>): Middleware {
+export function kvStatic(kvInit: KVInit): Middleware {
   return async (ctx, next) => {
+    const mOptions = kvInit.options
     // TODO: Store mime types in KV as well
     const contentTypes = {
       css: 'text/css',
@@ -53,37 +59,38 @@ export function kvStatic(kv: any, mOptions: Partial<SiteInit>): Middleware {
       return next()
     }
     // set up options from mOptions passed in and the default options
-    const options = Object.assign({}, defaultSiteInit, mOptions)
+    let options = Object.assign({}, defaultKVSiteOptions, mOptions)
     // set cache options by either evaluating the handler passed in
     // or whatever settings were passed in
-    let evalCacheOpts: CacheOptions = (function() {
+    const evalCacheOpts: Partial<CacheOptions> = (() => {
       switch (typeof mOptions.cacheControl) {
         case 'function':
           return mOptions.cacheControl(ctx.request)
         case 'object':
           return mOptions.cacheControl
         case 'undefined': //just returns default cache settings, but type safe
-          return typeof defaultSiteInit.cacheControl === 'function'
-            ? defaultSiteInit.cacheControl(ctx.request)
-            : defaultSiteInit.cacheControl
+          return typeof defaultKVSiteOptions.cacheControl === 'function'
+            ? defaultKVSiteOptions.cacheControl(ctx.request)
+            : defaultKVSiteOptions.cacheControl
       }
     })()
-    const cacheOpts: CacheOptions = Object.assign({}, defaultSiteInit.cacheControl, evalCacheOpts)
+    options.cacheControl = Object.assign({}, defaultCacheControl, evalCacheOpts)
 
     // TODO first try to match request will cache
     const filename = options.keyModifier(ctx.request.url)
     const ext = filename.substring(filename.lastIndexOf('.') + 1)
     const contentType = contentTypes[ext as keyof typeof contentTypes] || 'text'
-    const body = await kv.get(filename, 'stream')
+    const body = await kvInit.kv.get(filename, 'stream')
 
-    if (cacheOpts.edgeTTL && !cacheOpts.bypassCache) cache.put(filename, cacheOpts.edgeTTL)
+    if (options.cacheControl.edgeTTL && !options.cacheControl.bypassCache)
+      cache.put(filename, options.cacheControl.edgeTTL)
 
     if (!body) return ctx.end(await options.notFoundHandler(ctx.request))
 
     return ctx.end(body, {
       headers: {
         'Content-Type': contentType,
-        'Cache-Control': `max-age=${cacheOpts.browserTTL}`,
+        'Cache-Control': `max-age=${options.cacheControl.browserTTL}`,
       },
     })
   }

--- a/src/middleware/kv-static.ts
+++ b/src/middleware/kv-static.ts
@@ -32,7 +32,7 @@ const defaultSiteInit: SiteInit = {
  * Streams files out of KV if it exists
  * TODO KVNamespace should come from the wrangler config .. ?
  */
-export function kvStatic(kv: KVNamespace, mOptions: Partial<SiteInit>): Middleware {
+export function kvStatic(kv: any, mOptions: Partial<SiteInit>): Middleware {
   return async (ctx, next) => {
     // TODO: Store mime types in KV as well
     const contentTypes = {


### PR DESCRIPTION
use KV static sites as a middleware with optional ability to set:
* not found handler
* cache controls (browser TTL, edge TTL, bypass)
* key modifier

```javascript
import { Router, kvStatic } from '8track'

const router = new Router()

const githubApi = (req: Request) => new Response('blah')
router.get(/api\/github/).handle(githubApi(event.request))

const keyModifier = (path: string) => {
  path.replace('docs/', '')
  if (path.endsWith('/')) path.concat('index.html')
  return path
}
const myNotFound = (req: Request) =>
  new Response('Sorry page was not found', { status: 404 })
const siteInit: SiteInit = {
  keyModifer: keyModifier,
  notFoundHandler: myNotFound,
}

router.all(/nextbigthing*/).use(serveStaticSite(event, siteInit))
```