### PR TITLE
Allow null body for 'No Content' response

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "8track",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A service worker router with async middleware and neato type-inference inspired by Koa",
   "repository": {
     "url": "https://github.com/jrf0110/8track"

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -17,7 +17,7 @@ export class Context<Data = any, Params = any> {
     this.data = data
   }
 
-  end(body: string | ReadableStream | Response, responseInit: ResponseInit = {}) {
+  end(body: string | ReadableStream | Response | null, responseInit: ResponseInit = {}) {
     if (body instanceof Response) {
       this.response = body
       return this.response


### PR DESCRIPTION
Warning when passing string with status code 204:

```Constructing a Response with a null body status (204) and a non-null, zero-length body. This is technically incorrect, and we recommend you update your code to explicitly pass in a `null` body, e.g. `new Response(null, { status: 204, ... })`. (We continue to allow the zero-length body behavior because it was previously the only way to construct a Response with a null body status. This behavior may change in the future.)```

Allow null as the body to pass into `Response` when there is no content.