### PR TITLE
13 router mounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,9 @@ import { Router, handle } from '8track'
 const router = new Router()
 
 router.all`(.*)`.use(async (ctx, next) => {
-  const url = new URL(ctx.event.request.url)
-  console.log(`Handling ${ctx.event.request.method} - ${url.pathname}`)
+  console.log(`Handling ${ctx.event.request.method} - ${ctx.url.pathname}`)
   await next()
-  console.log(`${ctx.event.request.method} - ${url.pathname}`)
+  console.log(`${ctx.event.request.method} - ${ctx.url.pathname}`)
 })
 
 router.get`/`.handle((ctx) => ctx.html('Hello, world!'))
@@ -221,6 +220,24 @@ router.patch`/api/users/${'id'}`.use(async (ctx, next) => {
   console.log('After: User ID', ctx.params.id)
 })
 ```
+
+### Context
+
+Each route handler and middleware receives an instance of `Context`.
+
+#### Context Properties
+
+- `readonly event: FetchEvent`
+- `readonly params: Params`
+- `response: Response`
+- `data: Data`
+- `url: URL`
+
+#### Context Methods
+
+- `end(body: string | ReadableStream | Response | null, responseInit: ResponseInit = {})`
+- `html(body: string | ReadableStream, responseInit: ResponseInit = {})`
+- `json(body: any, responseInit: ResponseInit = {})`
 
 ##### What's up with that weird syntax?
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,22 @@ router.get`/users/${'userId'}`.handle((ctx) => {
 })
 ```
 
+#### Sub-router mounting
+
+```typescript
+const apiRouter = new Router()
+const usersRouter = new Router()
+const userBooksRouter = new Router()
+
+usersRouter.get`/`.handle((ctx) => ctx.end('users-list'))
+usersRouter.get`/${'id'}`.handle((ctx) => ctx.end(`user: ${ctx.params.id}`))
+userBooksRouter.get`/`.handle((ctx) => ctx.end('books-list'))
+userBooksRouter.get`/${'id'}`.handle((ctx) => ctx.end(`book: ${ctx.params.id}`))
+
+usersRouter.all`/${'id'}/books`.use(userBooksRouter)
+apiRouter.all`/api/users`.use(usersRouter)
+```
+
 ## API
 
 ### Router<RouteData>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "8track",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "A service worker router with async middleware and neato type-inference inspired by Koa",
   "repository": {
     "url": "https://github.com/jrf0110/8track"

--- a/src/Context.ts
+++ b/src/Context.ts
@@ -5,6 +5,7 @@ interface ContextProps<Data = any, Params = any> {
   response: Response
   params: Params
   data: Data
+  url: URL
 }
 /**
  * Middleware and handler context. Container to read data about a route
@@ -16,12 +17,14 @@ export class Context<Data = any, Params = any> {
   readonly params: Params
   response: Response
   data: Data
+  url: URL
 
-  constructor({ event, response, params, data }: ContextProps<Data, Params>) {
+  constructor({ event, response, params, data, url }: ContextProps<Data, Params>) {
     this.event = event
     this.response = response
     this.params = params
     this.data = data
+    this.url = url
   }
 
   end(body: string | ReadableStream | Response | null, responseInit: ResponseInit = {}) {

--- a/src/path.ts
+++ b/src/path.ts
@@ -1,0 +1,65 @@
+/**
+ * Taken from https://github.com/jfromaniello/url-join/blob/master/lib/url-join.js
+ */
+
+export function pathJoin(...strArray: string[]) {
+  var resultArray = []
+  if (strArray.length === 0) {
+    return ''
+  }
+
+  if (typeof strArray[0] !== 'string') {
+    throw new TypeError('Url must be a string. Received ' + strArray[0])
+  }
+
+  // If the first part is a plain protocol, we combine it with the next part.
+  if (strArray[0].match(/^[^/:]+:\/*$/) && strArray.length > 1) {
+    var first = strArray.shift()
+    strArray[0] = first + strArray[0]
+  }
+
+  // There must be two or three slashes in the file protocol, two slashes in anything else.
+  if (strArray[0].match(/^file:\/\/\//)) {
+    strArray[0] = strArray[0].replace(/^([^/:]+):\/*/, '$1:///')
+  } else {
+    strArray[0] = strArray[0].replace(/^([^/:]+):\/*/, '$1://')
+  }
+
+  for (var i = 0; i < strArray.length; i++) {
+    var component = strArray[i]
+
+    if (typeof component !== 'string') {
+      throw new TypeError('Url must be a string. Received ' + component)
+    }
+
+    if (component === '') {
+      continue
+    }
+
+    if (i > 0) {
+      // Removing the starting slashes for each component but the first.
+      component = component.replace(/^[\/]+/, '')
+    }
+    if (i < strArray.length - 1) {
+      // Removing the ending slashes for each component but the last.
+      component = component.replace(/[\/]+$/, '')
+    } else {
+      // For the last component we will combine multiple slashes to a single one.
+      component = component.replace(/[\/]+$/, '/')
+    }
+
+    resultArray.push(component)
+  }
+
+  var str = resultArray.join('/')
+  // Each input component is now separated by a single slash except the possible first plain protocol part.
+
+  // remove trailing slash before parameters or hash
+  str = str.replace(/\/(\?|&|#[^!])/g, '$1')
+
+  // replace ? in parameters with &
+  var parts = str.split('?')
+  str = parts.shift() + (parts.length > 0 ? '?' : '') + parts.join('&')
+
+  return str
+}


### PR DESCRIPTION
* Closes #13 
* Closes #44 

## Sub Router Mounting

```tsx
import { Router } from '8track'

const router = new Router()
const usersRouter = new Router()

usersRouter.get`/`.handle(async ctx => {
  // List users
})

usersRouter.post`/`.handle(async ctx => {
  // Create user
})

usersRouter.get`/${'userId'}`.handle(async ctx => {
  // Get user by ID
})

usersRouter.put`/${'userId'}`.handle(async ctx => {
  // Update user by ID
})

usersRouter.del`/${'userId'}`.handle(async ctx => {
  // Delete user by ID
})

router.all`/organization/${'organizationId'}/users`.use(usersRouter)
```

## `.url` property on Context

Middlewares frequently need to parse the `URL` and we end up with a ton of `new URL(event.request.url)` calls littered throughout the application. No more! Now you can use `ctx.url` to access a pre-parsed `URL` instance