### PR TITLE
fix: Set-Cookie header issue

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -11,11 +11,13 @@ export function mergeHeaders(...allHeaders: (Headers | object)[]): Headers {
   for (let ithHeader of allHeaders) {
     if (ithHeader instanceof Headers) {
       for (let [k, v] of ithHeader) {
-        result.set(k, v)
+        ithHeader.get('Set-Cookie') !== null ? result.append(k, v) : result.set(k, v)
       }
     } else {
       for (let key in ithHeader) {
-        result.set(key, (ithHeader as any)[key])
+        key === 'Set-Cookie'
+          ? result.append(key, (ithHeader as any)[key])
+          : result.set(key, (ithHeader as any)[key])
       }
     }
   }

--- a/src/util_test.ts
+++ b/src/util_test.ts
@@ -8,11 +8,35 @@ import { mergeHeaders } from './util'
 // returning the actual names of the variables I used [a, b]
 // instead of ['key', 'value']
 ;(global as any).Headers = Headers
-
 test('mergeHeaders(a, b)', (t) => {
   const a = mergeHeaders(new Headers({ foo: 'bar' }), {
     bar: 'baz',
   })
   t.is(a.get('foo'), 'bar')
   t.is(a.get('bar'), 'baz')
+})
+
+test('mergeHeaders(a,b) for multiple Set-Cookie headers', (t) => {
+  const a = mergeHeaders(
+    new Headers({ 'Set-Cookie': 'test1=1' }),
+    new Headers({ 'Set-Cookie': 'test2=2' }),
+    new Headers({ foo: 'bar' }),
+  )
+  t.is(a.get('foo'), 'bar')
+  t.is(a.get('Set-Cookie'), 'test1=1, test2=2')
+})
+
+test('mergeHeaders(a,b) for Set-Cookie header of type object', (t) => {
+  const a = mergeHeaders({ 'Set-Cookie': 'test1=1' }, new Headers({ foo: 'bar' }))
+  t.is(a.get('foo'), 'bar')
+  t.is(a.get('Set-Cookie'), 'test1=1')
+})
+test('mergeHeaders(a,b) for Set-Cookie header of type object and header', (t) => {
+  const a = mergeHeaders(
+    { 'Set-Cookie': 'test1=1' },
+    new Headers({ 'Set-Cookie': 'test2=2' }),
+    new Headers({ foo: 'bar' }),
+  )
+  t.is(a.get('foo'), 'bar')
+  t.is(a.get('Set-Cookie'), 'test1=1, test2=2')
 })


### PR DESCRIPTION
This will allow multiple cookies to be set
from the server by adding multiple 'Set-Cookie' fields
within the header response.

Before this fix, if there was multiple 'Set-Cookie' fields, it would
be merged into one string value and this is not allowed according to [rfc6265 standard](https://httpwg.org/specs/rfc6265.html#n-examples)

Before Fix:
```
// Response Header
Set-Cookie: "cookie1=1 cookie2=2"
```
After Fix:
```
// Response Header
Set-Cookie: "cookie1=1"
Set-Cookie: "cookie2=2"
```